### PR TITLE
Replace an article's link (instead of its content)

### DIFF
--- a/init.php
+++ b/init.php
@@ -142,7 +142,13 @@ class Af_Feedmod extends Plugin implements IHandler
                                     }
                                 }
                             }
-                            $article['content'] = $doc->saveXML($basenode);
+                            
+                            // modify the article
+                            if ($config['mod_link']) {
+                                $article['link'] = $basenode->textContent;
+                            } else {
+                                $article['content'] = $doc->saveXML($basenode);
+                            }
                             $article['plugin_data'] = "feedmod,$owner_uid:" . $article['plugin_data'];
                         }
                     }


### PR DESCRIPTION
Added a new option `mod_link` to allow the modification of an article's link.

*Example:*
http://feeds.feedburner.com/rivva
```json
"rivva.de": {
    "type": "xpath",
    "xpath": "header/h1/a/@href",
    "force_charset": "utf-8",
    "mod_link": true
}
```